### PR TITLE
Derive types using type reader

### DIFF
--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -1,18 +1,18 @@
 defmodule Breakfast do
-  alias Breakfast.Yogurt
+  alias Breakfast.{Type, Yogurt}
 
   @type quoted :: term()
 
-  @known_types [
-    :integer,
-    :number,
-    :float,
-    :string,
-    {:list, :integer},
-    {:list, :number},
-    {:list, :float},
-    {:list, :string}
-  ]
+  # @known_types [
+  #   :integer,
+  #   :number,
+  #   :float,
+  #   :string,
+  #   {:list, :integer},
+  #   {:list, :number},
+  #   {:list, :float},
+  #   {:list, :string}
+  # ]
 
   defmodule Field do
     defstruct [:mod, :name, :type, :fetcher, :caster, :validator, :default]
@@ -56,10 +56,10 @@ defmodule Breakfast do
       custom_fetchers = Enum.into(@breakfast_fetchers, %{})
       custom_default_values = Enum.into(@breakfast_default_values, %{})
 
-      unless unquote(cereal_caster), do: Breakfast.check_casters(raw_fields, custom_casters)
+      #      unless unquote(cereal_caster), do: Breakfast.check_casters(raw_fields, custom_casters)
 
-      unless unquote(cereal_validator),
-        do: Breakfast.check_validators(raw_fields, custom_validators)
+      #      unless unquote(cereal_validator),
+      #        do: Breakfast.check_validators(raw_fields, custom_validators)
 
       @breakfast_fields Enum.map(raw_fields, fn {name, type, _opts} = raw_field ->
                           %Field{mod: __MODULE__, name: name, type: type}
@@ -195,7 +195,7 @@ defmodule Breakfast do
   def check_validators(fields, validators) do
     Enum.each(fields, fn {name, type, opts} ->
       with false <- Keyword.has_key?(opts, :validate),
-           false <- Enum.member?(@known_types, type),
+           #           false <- Enum.member?(@known_types, type),
            false <- Map.has_key?(validators, type),
            false <- match?({:cereal, _}, type) do
         raise "%CompileError{}: No validator for :#{name}"
@@ -206,7 +206,7 @@ defmodule Breakfast do
   def check_casters(fields, casters) do
     Enum.each(fields, fn {name, type, opts} ->
       with false <- Keyword.has_key?(opts, :cast),
-           false <- Enum.member?(@known_types, type),
+           #           false <- Enum.member?(@known_types, type),
            false <- Map.has_key?(casters, type),
            false <- match?({:cereal, _}, type) do
         raise "%CompileError{}: No cast for :#{name}"
@@ -215,7 +215,7 @@ defmodule Breakfast do
   end
 
   defmacro field(name, spec, opts \\ []) do
-    type = type_from_spec(spec)
+    type = Type.derive_from_spec(spec)
 
     quote do
       Module.put_attribute(
@@ -245,7 +245,7 @@ defmodule Breakfast do
   end
 
   defmacro type(spec, opts) do
-    type = type_from_spec(spec)
+    type = Type.derive_from_spec(spec)
 
     quote bind_quoted: [type: type, opts: opts] do
       validate = Keyword.get(opts, :validate)
@@ -260,19 +260,32 @@ defmodule Breakfast do
     end
   end
 
-  defp type_from_spec([spec]), do: {:list, type_from_spec(spec)}
-  defp type_from_spec({:float, _, []}), do: :float
-  defp type_from_spec({:integer, _, []}), do: :integer
-  defp type_from_spec({:map, _, []}), do: :map
-  defp type_from_spec({:number, _, []}), do: :number
-  defp type_from_spec({{:., _, [{:__aliases__, _, [:String]}, :t]}, _, []}), do: :string
+  # defp type_from_spec(spec) do
+  #   case TypeReader.type_from_quoted(spec) do
+  #     {:ok, %TypeReader.TerminalType{name: type, bindings: []}} ->
+  #       type
+  #       {:ok, %TypeReader.TerminalType{name: :list, bindings: [
+  #                                         type: %TypeReader.TerminalType{name: }
+  #                                       ]}} ->
+  #     :error ->
+  #       IO.inspect(spec, label: "Fail")
+  #       raise "AH"
+  #   end
+  # end
 
-  defp type_from_spec({:cereal, _cereal_module_alias} = type), do: type
+  # defp type_from_spec([spec]), do: {:list, type_from_spec(spec)}
+  # defp type_from_spec({:float, _, []}), do: :float
+  # defp type_from_spec({:integer, _, []}), do: :integer
+  # defp type_from_spec({:map, _, []}), do: :map
+  # defp type_from_spec({:number, _, []}), do: :number
+  # defp type_from_spec({{:., _, [{:__aliases__, _, [:String]}, :t]}, _, []}), do: :string
 
-  defp type_from_spec({{:., _, [{:__aliases__, _, alias_}, type]}, _, _type_params}),
-    do: {:custom, {alias_, type}}
+  # defp type_from_spec({:cereal, _cereal_module_alias} = type), do: type
 
-  defp type_from_spec({type, _, _}), do: {:custom, type}
+  # defp type_from_spec({{:., _, [{:__aliases__, _, alias_}, type]}, _, _type_params}),
+  #   do: {:custom, {alias_, type}}
+
+  # defp type_from_spec({type, _, _}), do: {:custom, type}
 
   @spec decode(mod :: module(), params :: term()) :: %Yogurt{}
   def decode(mod, params) do

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -154,7 +154,7 @@ defmodule Breakfast do
     end
   end
 
-  def cast(value, %Field{caster: :default, type: type}), do: Breakfast.Type.cast(type, value)
+  def cast(value, %Field{caster: :default}), do: {:ok, value}
 
   def cast(value, %Field{mod: mod, caster: caster}), do: apply_fn(mod, caster, [value])
 

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -1,19 +1,6 @@
 defmodule Breakfast do
   alias Breakfast.{Type, Yogurt}
 
-  @type quoted :: term()
-
-  # @known_types [
-  #   :integer,
-  #   :number,
-  #   :float,
-  #   :string,
-  #   {:list, :integer},
-  #   {:list, :number},
-  #   {:list, :float},
-  #   {:list, :string}
-  # ]
-
   defmodule Field do
     defstruct [:mod, :name, :type, :fetcher, :caster, :validator, :default]
   end
@@ -55,8 +42,6 @@ defmodule Breakfast do
       custom_casters = Enum.into(@breakfast_casters, %{})
       custom_fetchers = Enum.into(@breakfast_fetchers, %{})
       custom_default_values = Enum.into(@breakfast_default_values, %{})
-
-      #      unless unquote(cereal_caster), do: Breakfast.check_casters(raw_fields, custom_casters)
 
       #      unless unquote(cereal_validator),
       #        do: Breakfast.check_validators(raw_fields, custom_validators)
@@ -203,17 +188,6 @@ defmodule Breakfast do
     end)
   end
 
-  def check_casters(fields, casters) do
-    Enum.each(fields, fn {name, type, opts} ->
-      with false <- Keyword.has_key?(opts, :cast),
-           #           false <- Enum.member?(@known_types, type),
-           false <- Map.has_key?(casters, type),
-           false <- match?({:cereal, _}, type) do
-        raise "%CompileError{}: No cast for :#{name}"
-      end
-    end)
-  end
-
   defmacro field(name, spec, opts \\ []) do
     type = Type.derive_from_spec(spec)
 
@@ -260,33 +234,6 @@ defmodule Breakfast do
     end
   end
 
-  # defp type_from_spec(spec) do
-  #   case TypeReader.type_from_quoted(spec) do
-  #     {:ok, %TypeReader.TerminalType{name: type, bindings: []}} ->
-  #       type
-  #       {:ok, %TypeReader.TerminalType{name: :list, bindings: [
-  #                                         type: %TypeReader.TerminalType{name: }
-  #                                       ]}} ->
-  #     :error ->
-  #       IO.inspect(spec, label: "Fail")
-  #       raise "AH"
-  #   end
-  # end
-
-  # defp type_from_spec([spec]), do: {:list, type_from_spec(spec)}
-  # defp type_from_spec({:float, _, []}), do: :float
-  # defp type_from_spec({:integer, _, []}), do: :integer
-  # defp type_from_spec({:map, _, []}), do: :map
-  # defp type_from_spec({:number, _, []}), do: :number
-  # defp type_from_spec({{:., _, [{:__aliases__, _, [:String]}, :t]}, _, []}), do: :string
-
-  # defp type_from_spec({:cereal, _cereal_module_alias} = type), do: type
-
-  # defp type_from_spec({{:., _, [{:__aliases__, _, alias_}, type]}, _, _type_params}),
-  #   do: {:custom, {alias_, type}}
-
-  # defp type_from_spec({type, _, _}), do: {:custom, type}
-
   @spec decode(mod :: module(), params :: term()) :: %Yogurt{}
   def decode(mod, params) do
     Enum.reduce(
@@ -324,7 +271,7 @@ defmodule Breakfast do
                   }"
 
           {:validate, retval} ->
-            raise "Expected #{name}.validate (#{inspect(validator)}) to return a list, got #{
+            raise "Expected #{name}.validate (#{inspect(validator)}) to return a list, got: #{
                     inspect(retval)
                   }"
         end

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -43,9 +43,6 @@ defmodule Breakfast do
       custom_fetchers = Enum.into(@breakfast_fetchers, %{})
       custom_default_values = Enum.into(@breakfast_default_values, %{})
 
-      #      unless unquote(cereal_validator),
-      #        do: Breakfast.check_validators(raw_fields, custom_validators)
-
       @breakfast_fields Enum.map(raw_fields, fn {name, type, _opts} = raw_field ->
                           %Field{mod: __MODULE__, name: name, type: type}
                           |> Breakfast.set_fetcher(custom_fetchers, unquote(cereal_fetcher))
@@ -176,17 +173,6 @@ defmodule Breakfast do
 
   defp apply_fn(_mod, {mod, fun}, args) when is_atom(mod) and is_atom(fun) and is_list(args),
     do: apply(mod, fun, args)
-
-  def check_validators(fields, validators) do
-    Enum.each(fields, fn {name, type, opts} ->
-      with false <- Keyword.has_key?(opts, :validate),
-           #           false <- Enum.member?(@known_types, type),
-           false <- Map.has_key?(validators, type),
-           false <- match?({:cereal, _}, type) do
-        raise "%CompileError{}: No validator for :#{name}"
-      end
-    end)
-  end
 
   defmacro field(name, spec, opts \\ []) do
     type = Type.derive_from_spec(spec)

--- a/lib/breakfast/test_definitions.ex
+++ b/lib/breakfast/test_definitions.ex
@@ -1,0 +1,5 @@
+if Mix.env() == :test do
+  defmodule Breakfast.TestDefinitions do
+    @type status :: :approved | :pending | :rejected
+  end
+end

--- a/lib/breakfast/test_definitions.ex
+++ b/lib/breakfast/test_definitions.ex
@@ -1,5 +1,8 @@
 if Mix.env() == :test do
   defmodule Breakfast.TestDefinitions do
     @type status :: :approved | :pending | :rejected
+
+    @type rgb_color :: :red | :green | :blue
+    @type cmyk_color :: :cyan | :magenta | :yellow | :black
   end
 end

--- a/lib/breakfast/test_definitions.ex
+++ b/lib/breakfast/test_definitions.ex
@@ -1,3 +1,7 @@
+##
+# this is code used by tests to run certain assertions. it is being compiled
+# in lib versus within a test module due to the way Elixir throws out doc/type information
+# w/ test modules
 if Mix.env() == :test do
   defmodule Breakfast.TestDefinitions do
     @type status :: :approved | :pending | :rejected

--- a/lib/breakfast/type.ex
+++ b/lib/breakfast/type.ex
@@ -88,6 +88,22 @@ defmodule Breakfast.Type do
 
   def cast({:list, _type}, _term), do: :error
 
+  def validate({:union, union_types}, term) do
+    if Enum.any?(union_types, &(validate(&1, term) == [])) do
+      []
+    else
+      ["expected one of #{inspect(union_types)}, got: #{inspect(term)}"]
+    end
+  end
+
+  def validate({:literal, literal_value}, term) do
+    if literal_value == term do
+      []
+    else
+      ["expected #{literal_value}, got: #{inspect(term)}"]
+    end
+  end
+
   def validate(:binary, term) when is_binary(term), do: []
   def validate(:binary, term), do: ["expected a string, got #{inspect(term)}"]
 

--- a/lib/breakfast/type.ex
+++ b/lib/breakfast/type.ex
@@ -43,52 +43,6 @@ defmodule Breakfast.Type do
     {:ok, type_name}
   end
 
-  def cast(:binary, term) when is_binary(term), do: {:ok, term}
-  def cast(:binary, _term), do: :error
-
-  def cast(:integer, term) when is_integer(term), do: {:ok, term}
-
-  def cast(:integer, term) when is_binary(term) do
-    case Integer.parse(term) do
-      {integer, _} -> {:ok, integer}
-      _ -> :error
-    end
-  end
-
-  def cast(:integer, _term), do: :error
-
-  def cast(:float, term) when is_float(term), do: {:ok, term}
-
-  def cast(:float, term) when is_binary(term) do
-    case Float.parse(term) do
-      {float, _} -> {:ok, float}
-      _ -> :error
-    end
-  end
-
-  def cast(:number, term) when is_number(term), do: {:ok, term}
-
-  def cast(:number, term) when is_binary(term) do
-    with :error <- Integer.parse(term),
-         :error <- Float.parse(term),
-         do: :error,
-         else: ({_number, _} -> :error)
-  end
-
-  def cast({:list, type}, term) when is_list(term) do
-    list_or_error =
-      Enum.reduce_while(term, [], fn t, acc ->
-        case cast(type, t) do
-          {:ok, t} -> {:cont, [t | acc]}
-          :error -> {:halt, :error}
-        end
-      end)
-
-    with list when is_list(list) <- list_or_error, do: {:ok, Enum.reverse(list)}
-  end
-
-  def cast({:list, _type}, _term), do: :error
-
   def validate({:tuple, union_types}, term) do
     with true <- is_tuple(term),
          term_as_list = Tuple.to_list(term),

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Breakfast.MixProject do
 
   defp deps do
     [
+      {:type_reader, github: "MainShayne233/type_reader"},
       {:mix_test_watch, "~> 0.8", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.7", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.12.0", only: [:dev, :test], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,6 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.9.0", "c72132a6071261893518fa08e121e911c9358713f62794a90c95db59042af375", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
+  "type_reader": {:git, "https://github.com/MainShayne233/type_reader.git", "82871f44099258e56d90617ec6fe97d803cb2bca", []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -78,7 +78,7 @@ defmodule BreakfastTest do
       params = Map.put(params, "email", :shayneAThotmailDOTcom)
       result = Breakfast.decode(Client.User, params)
 
-      assert result.errors == [email: "cast error"]
+      assert result.errors == [email: "expected a string, got :shayneAThotmailDOTcom"]
     end
   end
 
@@ -205,7 +205,12 @@ defmodule BreakfastTest do
 
       result = Breakfast.decode(__MODULE__, bad_params)
 
-      assert result.errors == [config: [timezone: "cast error", sleep_timeout: "cast error"]]
+      assert result.errors == [
+               config: [
+                 timezone: "expected a string, got :UTC",
+                 sleep_timeout: "expected an integer, got []"
+               ]
+             ]
     end
   end
 
@@ -311,7 +316,7 @@ defmodule BreakfastTest do
       params = %{params | "tag_groupings" => ["user", "admin"]}
 
       result = Breakfast.decode(__MODULE__, params)
-      assert result.errors == [tag_groupings: "cast error"]
+      assert result.errors == [tag_groupings: "expected a list, got \"user\""]
     end
 
     test "should support tuples", %{params: params} do

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -263,12 +263,16 @@ defmodule BreakfastTest do
 
     setup do
       %{
-        params: %{"rgb_color" => "blue"}
+        params: %{
+          "rgb_color" => "blue",
+          "tag_groupings" => [["guest"], ["user", "admin"]]
+        }
       }
     end
 
     cereal do
       field :rgb_color, Breakfast.TestDefinitions.rgb_color(), cast: :string_to_existing_atom
+      field :tag_groupings, [[String.t()]]
     end
 
     def string_to_existing_atom(binary) do
@@ -282,17 +286,26 @@ defmodule BreakfastTest do
       result = Breakfast.decode(__MODULE__, params)
       assert result.errors == []
 
-      params = %{"rgb_color" => "green"}
+      params = %{params | "rgb_color" => "green"}
       result = Breakfast.decode(__MODULE__, params)
       assert result.errors == []
 
-      params = %{"rgb_color" => "cyan"}
+      params = %{params | "rgb_color" => "cyan"}
       result = Breakfast.decode(__MODULE__, params)
 
       assert result.errors == [
                rgb_color:
                  "expected one of [literal: :red, literal: :green, literal: :blue], got: :cyan"
              ]
+    end
+
+    test "should handle multi-dimensional lists", %{params: params} do
+      result = Breakfast.decode(__MODULE__, params)
+      assert result.errors == []
+
+      params = %{params | "tag_groupings" => ["user", "admin"]}
+      result = Breakfast.decode(__MODULE__, params)
+      assert result.errors == [tag_groupings: "cast error"]
     end
   end
 end

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -85,34 +85,15 @@ defmodule BreakfastTest do
   testmodule InferValidator do
     use Breakfast
 
+    @tag :only
     test "should give a helpful error if unable to infer the validator for a custom type" do
-      assert assert_raise(RuntimeError, fn ->
-               defmodule Client.Request do
-                 use Breakfast
-                 @type status :: :approved | :pending | :rejected
+      defmodule Client.Request do
+        use Breakfast
 
-                 cereal do
-                   field(:statuses, Client.status())
-                 end
-               end
-             end) == %RuntimeError{message: "%CompileError{}: No cast for :statuses"}
-
-      assert (defmodule Client.Request do
-                use Breakfast
-                @type status :: :approved | :pending | :rejected
-
-                cereal do
-                  field(:statuses, [Client.status()],
-                    cast: :cast_statuses,
-                    validate: :validate_statuses
-                  )
-                end
-
-                def cast_statuses(value), do: value
-
-                def validate_statuses(statuses),
-                  do: Enum.all?(statuses, &(&1 in [:approved, :pending, :rejected]))
-              end)
+        cereal do
+          field(:statuses, Breakfast.TestDefinitions.status())
+        end
+      end
     end
   end
 

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -334,14 +334,14 @@ defmodule BreakfastTest do
 
     test "should raise error when type cannot be determined" do
       assert assert_raise(RuntimeError, fn ->
-        defmodule WillRaise do
-          use Breakfast
+               defmodule WillRaise do
+                 use Breakfast
 
-          cereal do
-            field :crazy, DoesNotExist.t()
-          end
-        end
-      end) == %RuntimeError{message: "Failed to derive type from spec: DoesNotExist.t()"}
+                 cereal do
+                   field :crazy, DoesNotExist.t()
+                 end
+               end
+             end) == %RuntimeError{message: "Failed to derive type from spec: DoesNotExist.t()"}
     end
   end
 end

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -70,7 +70,7 @@ defmodule BreakfastTest do
                Breakfast.decode(Client.User, params)
              end) == %RuntimeError{
                message:
-                 "Expected status.validate (:validate_status) to return a list, got :bad_return"
+                 "Expected status.validate (:validate_status) to return a list, got: :bad_return"
              }
     end
 
@@ -78,7 +78,7 @@ defmodule BreakfastTest do
       params = Map.put(params, "email", :shayneAThotmailDOTcom)
       result = Breakfast.decode(Client.User, params)
 
-      assert result.errors == [email: "expected a string, got :shayneAThotmailDOTcom"]
+      assert result.errors == [email: "expected a binary, got: :shayneAThotmailDOTcom"]
     end
   end
 
@@ -207,8 +207,8 @@ defmodule BreakfastTest do
 
       assert result.errors == [
                config: [
-                 timezone: "expected a string, got :UTC",
-                 sleep_timeout: "expected an integer, got []"
+                 timezone: "expected a binary, got: :UTC",
+                 sleep_timeout: "expected a integer, got: []"
                ]
              ]
     end
@@ -316,7 +316,7 @@ defmodule BreakfastTest do
       params = %{params | "tag_groupings" => ["user", "admin"]}
 
       result = Breakfast.decode(__MODULE__, params)
-      assert result.errors == [tag_groupings: "expected a list, got \"user\""]
+      assert result.errors == [tag_groupings: "expected a list, got: \"user\""]
     end
 
     test "should support tuples", %{params: params} do
@@ -326,6 +326,22 @@ defmodule BreakfastTest do
       params = %{params | "ratio" => [7, 5.0]}
       result = Breakfast.decode(__MODULE__, params)
       assert result.errors == [ratio: "expected {:integer, :integer}, got: {7, 5.0}"]
+    end
+  end
+
+  testmodule TypeError do
+    use Breakfast
+
+    test "should raise error when type cannot be determined" do
+      assert assert_raise(RuntimeError, fn ->
+        defmodule WillRaise do
+          use Breakfast
+
+          cereal do
+            field :crazy, DoesNotExist.t()
+          end
+        end
+      end) == %RuntimeError{message: "Failed to derive type from spec: DoesNotExist.t()"}
     end
   end
 end

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -265,7 +265,8 @@ defmodule BreakfastTest do
       %{
         params: %{
           "rgb_color" => "blue",
-          "tag_groupings" => [["guest"], ["user", "admin"]]
+          "tag_groupings" => [["guest"], ["user", "admin"]],
+          "ratio" => [1, 2]
         }
       }
     end
@@ -273,7 +274,11 @@ defmodule BreakfastTest do
     cereal do
       field :rgb_color, Breakfast.TestDefinitions.rgb_color(), cast: :string_to_existing_atom
       field :tag_groupings, [[String.t()]]
+      field :ratio, {integer(), integer()}, cast: :pair_from_list
     end
+
+    def pair_from_list([lhs, rhs]), do: {:ok, {lhs, rhs}}
+    def pair_from_list(_), do: :error
 
     def string_to_existing_atom(binary) do
       {:ok, String.to_existing_atom(binary)}
@@ -304,8 +309,18 @@ defmodule BreakfastTest do
       assert result.errors == []
 
       params = %{params | "tag_groupings" => ["user", "admin"]}
+
       result = Breakfast.decode(__MODULE__, params)
       assert result.errors == [tag_groupings: "cast error"]
+    end
+
+    test "should support tuples", %{params: params} do
+      result = Breakfast.decode(__MODULE__, params)
+      assert result.errors == []
+
+      params = %{params | "ratio" => [7, 5.0]}
+      result = Breakfast.decode(__MODULE__, params)
+      assert result.errors == [ratio: "expected {:integer, :integer}, got: {7, 5.0}"]
     end
   end
 end

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -257,4 +257,42 @@ defmodule BreakfastTest do
              }
     end
   end
+
+  testmodule ComplexTypes do
+    use Breakfast
+
+    setup do
+      %{
+        params: %{"rgb_color" => "blue"}
+      }
+    end
+
+    cereal do
+      field :rgb_color, Breakfast.TestDefinitions.rgb_color(), cast: :string_to_existing_atom
+    end
+
+    def string_to_existing_atom(binary) do
+      {:ok, String.to_existing_atom(binary)}
+    rescue
+      _ in ArgumentError ->
+        :error
+    end
+
+    test "should handle union types", %{params: params} do
+      result = Breakfast.decode(__MODULE__, params)
+      assert result.errors == []
+
+      params = %{"rgb_color" => "green"}
+      result = Breakfast.decode(__MODULE__, params)
+      assert result.errors == []
+
+      params = %{"rgb_color" => "cyan"}
+      result = Breakfast.decode(__MODULE__, params)
+
+      assert result.errors == [
+               rgb_color:
+                 "expected one of [literal: :red, literal: :green, literal: :blue], got: :cyan"
+             ]
+    end
+  end
 end

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -85,7 +85,6 @@ defmodule BreakfastTest do
   testmodule InferValidator do
     use Breakfast
 
-    @tag :only
     test "should give a helpful error if unable to infer the validator for a custom type" do
       defmodule Client.Request do
         use Breakfast


### PR DESCRIPTION
This does a few things:

- Replaced the type-infering code w/ code that leans on `TypeReader`
- Remove basic type casts (if no cast is specified for basic types, no cast occurs)
- Remove cast/validate checks and instead raise if an understood type could not be determined for the field.