### PR TITLE
Validate options given to cereal, field and type

### DIFF
--- a/ROADMAP/v0.1.md
+++ b/ROADMAP/v0.1.md
@@ -58,6 +58,9 @@ The following are the features, behaviors, and general requirements of `Breakfas
 - [ ] A helpful compile-time error should raise if invalid options are passed to the cereal call
 - [ ] A helpful compile-time error should raise if invalid options are passed to the field call
 - [x] A helpful compile-time error should raise if invalid options are passed to the type call
+- [x] A helpful compile-time error should raise if unknown options are passed to the cereal call
+- [x] A helpful compile-time error should raise if unknown options are passed to the field call
+- [x] A helpful compile-time error should raise if unknown options are passed to the type call
 - [ ] A helpful compile-time error should raise if a type is not understood
 - [x] A helpful runtime error should raise if a fetch returns an invalid type
 - [x] A helpful runtime error should raise if a cast returns an invalid type

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -387,6 +387,53 @@ defmodule BreakfastTest do
 
       assert "Incomplete cereal definition, it's missing a `do` block." = message
     end
+
+    test "should raise a compile-time error when field is given one or more invalid options" do
+      %Breakfast.CompileError{message: message} =
+        assert_raise Breakfast.CompileError, fn ->
+          defmodule WillRaise do
+            use Breakfast
+
+            cereal do
+              field :crazy, atom(), invalid_opt_1: :a, invalid_opt_2: :b
+            end
+          end
+        end
+
+      assert "\n\n  Invalid options given to `field`: :invalid_opt_1, :invalid_opt_2." <> _ =
+               message
+    end
+
+    test "should raise a compile-time error when type is given one or more invalid options" do
+      %Breakfast.CompileError{message: message} =
+        assert_raise Breakfast.CompileError, fn ->
+          defmodule WillRaise do
+            use Breakfast
+
+            cereal do
+              type atom(), invalid_opt_1: :a, invalid_opt_2: :b
+            end
+          end
+        end
+
+      assert "\n\n  Invalid options given to `type`: :invalid_opt_1, :invalid_opt_2." <> _ =
+               message
+    end
+
+    test "should raise a compile-time error when cereal is given one or more invalid options" do
+      %Breakfast.CompileError{message: message} =
+        assert_raise Breakfast.CompileError, fn ->
+          defmodule WillRaise do
+            use Breakfast
+
+            cereal invalid_opt_1: :a, invalid_opt_2: :b do
+            end
+          end
+        end
+
+      assert "\n\n  Invalid options given to `cereal`: :invalid_opt_1, :invalid_opt_2." <> _ =
+               message
+    end
   end
 
   describe "README examples" do


### PR DESCRIPTION
This is just making sure the user isn't passing an unknown option to `cereal`, `field` or `type` but it doesn't validate the value of the option yet.