### PR TITLE
0.1.0 - Unwrap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ We decided to not use `:ok | :error` tuples as the return type for the following
 - There's a lot of context to return that you may or may not want to use (i.e. errors, input params, etc)
 - You can still pattern match on any case that you care about handling in your code
 
-However, for convenience, there is a `Breakfast.decode/1` function that will:
+However, for convenience, there is a `Breakfast.unwrap/1` function that will:
 - Return the decoded struct if there were no decoding erros
 - Return the `%Yogurt{}` otherwise
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,14 @@ iex> request = %{"lhs" => 5.0, "rhs" => 2, "operation" => "%"}
 ```
 <!--- MARKDOWN_TEST_END -->
 
-For convenience, there is a `Breakfast.decode/1` function that will:
+#### What about `:ok | :error` tuples?
+
+We decided to not use `:ok | :error` tuples as the return type for the following reasons:
+- We wanted to have a consistent type for the return value (it's always a `Yogurt.t()`, no matter what)
+- There's a lot of context to return that you may or may not want to use (i.e. errors, input params, etc)
+- You can still pattern match on any case that you care about handling in your code
+
+However, for convenience, there is a `Breakfast.decode/1` function that will:
 - Return the decoded struct if there were no decoding erros
 - Return the `%Yogurt{}` otherwise
 

--- a/README.md
+++ b/README.md
@@ -419,42 +419,6 @@ We decided to not use `:ok | :error` tuples as the return type for the following
 - There's a lot of context to return that you may or may not want to use (i.e. errors, input params, etc)
 - You can still pattern match on any case that you care about handling in your code
 
-However, for convenience, there is a `Breakfast.unwrap/1` function that will:
-- Return the decoded struct if there were no decoding erros
-- Return the `%Yogurt{}` otherwise
-
-<!--- MARKDOWN_TEST_START -->
-```elixir
-defmodule Person do
-  use Breakfast
-
-  cereal do
-    field(:first_name, String.t())
-    field(:last_name, String.t())
-  end
-
-  def greet(raw_user) do
-    result = Breakfast.decode(Person, raw_user)
-
-    case Breakfast.unwrap(result) do
-      %Person{first_name: first_name, last_name: last_name} ->
-        "Hello, #{first_name} #{last_name}!"
-
-      %Breakfast.Yogurt{} ->
-        "I'm not sure how to address you..."
-    end
-  end
-end
-
-iex> Person.greet(%{"first_name" => "Sean", "last_name" => "Neas"})
-"Hello, Sean Neas!"
-
-iex> Person.greet(%{"first_name" => "Sean", "last_name" => nil})
-"I'm not sure how to address you..."
-```
-<!--- MARKDOWN_TEST_END -->
-
-
 ## Current State
 
 Development of `v0.1` is currently underyway! Checkout out the [roadmap](./ROADMAP/v0.1.md) to see what's comming/if you are looking to contribute!

--- a/ROADMAP/v0.1.md
+++ b/ROADMAP/v0.1.md
@@ -5,7 +5,6 @@ The following are the features, behaviors, and general requirements of `Breakfas
 - [x] Clear intent of goals and use-case
 - [x] Examples expressing both the power and simplicity
 - [ ] A `Breakfast.decode/2` function that runs the decoding procedure against some params
-- [x] A `Breakfast.unwrap/1` function that returns the struct if valid, and returns the yogurt if invalid
 - [ ] Only the defined function should be exposed from the `Breakfast` module
 - [ ] Out of the box, a decoder should properly parse a plain, string-keyed Elixir map
 - [x] Should be able to automatically support the following types:

--- a/ROADMAP/v0.1.md
+++ b/ROADMAP/v0.1.md
@@ -5,7 +5,7 @@ The following are the features, behaviors, and general requirements of `Breakfas
 - [x] Clear intent of goals and use-case
 - [x] Examples expressing both the power and simplicity
 - [ ] A `Breakfast.decode/2` function that runs the decoding procedure against some params
-- [ ] A `Breakfast.unwrap/1` function that returns the struct if valid, and returns the yogurt if invalid
+- [x] A `Breakfast.unwrap/1` function that returns the struct if valid, and returns the yogurt if invalid
 - [ ] Only the defined function should be exposed from the `Breakfast` module
 - [ ] Out of the box, a decoder should properly parse a plain, string-keyed Elixir map
 - [x] Should be able to automatically support the following types:

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -73,18 +73,6 @@ defmodule Breakfast do
     %Yogurt{yogurt | errors: Enum.reverse(yogurt.errors)}
   end
 
-  @doc """
-  This function will either:
-  - Return the decoded struct if there were no decoding errors
-  - Return the `Yogurt.t()` if  there were any decoding errors
-
-  This function can be used for control flow, where you can match on the expected struct in the success case,
-  and match on the `Yogurt.t()` in the error case.
-  """
-  @spec unwrap(Yogurt.t()) :: Yogurt.t() | struct()
-  def unwrap(%Yogurt{errors: [], struct: struct}), do: struct
-  def unwrap(%Yogurt{errors: errors} = yogurt) when is_list(errors), do: yogurt
-
   @spec fetch(term(), Field.t()) :: result(term())
   defp fetch(params, field) do
     with :error <- do_fetch(params, field), do: field.default

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -73,6 +73,14 @@ defmodule Breakfast do
     %Yogurt{yogurt | errors: Enum.reverse(yogurt.errors)}
   end
 
+  @doc """
+  This function will either:
+  - Return the decoded struct if there were no decoding errors
+  - Return the `Yogurt.t()` if  there were any decoding errors
+
+  This function can be used for control flow, where you can match on the expected struct in the success case,
+  and match on the `Yogurt.t()` in the error case.
+  """
   @spec unwrap(Yogurt.t()) :: Yogurt.t() | struct()
   def unwrap(%Yogurt{errors: [], struct: struct}), do: struct
   def unwrap(%Yogurt{errors: errors} = yogurt) when is_list(errors), do: yogurt


### PR DESCRIPTION
This establishes some core documentation around using `Breakfast.unwrap/1`

I'm starting to get unsure about the need for this function versus just pattern matching on the `Yogurt.t()`.... but would love to hear arguments for why it'd be valuable.