### PR TITLE
Add fields to Yogurt

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ iex> data = %{
   errors: [],
   params: %{"email" => "john@aol.com", "id" => 1, "roles" => ["admin", "exec"]},
   struct: %User{email: "john@aol.com", id: 1, roles: ["admin", "exec"]},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :id, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :email, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :roles, type: {:list, :binary}, validator: :default}]
 }
 
 iex> data = %{
@@ -118,7 +118,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [roles: "expected a list of type :binary, got a list with at least one invalid element: expected a binary, got: :exec"],
   params: %{"email" => "john@aol.com", "id" => 1, "roles" => ["admin", :exec]},
-  struct: %User{email: "john@aol.com", id: 1, roles: nil}
+  struct: %User{email: "john@aol.com", id: 1, roles: nil},
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :id, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :email, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :roles, type: {:list, :binary}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -201,7 +202,7 @@ iex> data = %{
   errors: [],
   params: %{"age" => 67, "email" => "leo@aol.com", "roles" => ["exec", "admin"]},
   struct: %User{age: 67, email: "leo@aol.com", roles: ["exec", "admin"]},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine195.User, name: :email, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine195.User, name: :age, type: :non_neg_integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine195.User, name: :roles, type: {:list, :binary}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -234,7 +235,7 @@ iex> data = %{
   errors: [age: "expected a non_neg_integer, got: -5"],
   params: %{"age" => -5, "name" => "Sean"},
   struct: %User{age: nil, name: "Sean"},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine229.User, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine229.User, name: :age, type: :non_neg_integer, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -261,7 +262,7 @@ iex> data = %{
   errors: [],
   params: %{"payload" => %{"some" => "data"}, "status" => :success},
   struct: %Request{payload: %{"some" => "data"}, status: :success},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :payload, type: :map, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :status, type: {:union, [literal: :pending, literal: :success, literal: :failed]}, validator: :default}]
 }
 
 iex> data = %{
@@ -273,7 +274,7 @@ iex> data = %{
   errors: [status: "expected one of :pending | :success | :failed, got: :waiting"],
   params: %{"payload" => %{"some" => "data"}, "status" => :waiting},
   struct: %Request{payload: %{"some" => "data"}, status: nil},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :payload, type: :map, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :status, type: {:union, [literal: :pending, literal: :success, literal: :failed]}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -385,7 +386,7 @@ iex> data = %{
   errors: [],
   params: %{"SettingsName" => "Control Pannel", "timeout" => "1500", "volume" => 8},
   struct: %Settings{name: "Control Pannel", timeout: 1500, volume: 8},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :volume, type: :integer, validator: :valid_volume}]
 }
 
 iex> data = %{
@@ -398,7 +399,7 @@ iex> data = %{
   errors: [name: "value not found", timeout: "cast error", volume: "expected an integer in 0..100, got: -100"],
   params: %{"name" => "Control Pannel", "timeout" => 1500, "volume" => -100},
   struct: %Settings{name: nil, timeout: nil, volume: nil},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :volume, type: :integer, validator: :valid_volume}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -447,7 +448,7 @@ iex> data = %{"R" => "10", "G" => "20", "B" => "30"}
   errors: [],
   params: %{"B" => "30", "G" => "20", "R" => "10"},
   struct: %RGBColor{b: 30, g: 20, r: 10},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
 }
 
 iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
@@ -456,7 +457,7 @@ iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
   errors: [r: "value not found", g: "cast error", b: "expected an integer between 0 and 255, got: 500"],
   params: %{"B" => "500", "G" => "Twenty", "r" => "10"},
   struct: %RGBColor{b: nil, g: nil, r: nil},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -492,7 +493,7 @@ iex> data = ["Sully", 37, "sully@aol.com"]
   errors: [],
   params: ["Sully", 37, "sully@aol.com"],
   struct: %SpreadsheetRow{age: 37, email: "sully@aol.com", name: "Sully"},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine490.SpreadsheetRow, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine490.SpreadsheetRow, name: :age, type: :non_neg_integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine490.SpreadsheetRow, name: :email, type: :binary, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -526,7 +527,7 @@ iex> data = %{
     tags: [],
     title: "Cool Thing I Did"
   },
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :tags, type: {:list, :binary}, validator: :default}]
 }
 
 iex> data = %{
@@ -543,7 +544,7 @@ iex> data = %{
     tags: ["blockchain", "crypto"],
     title: "Cool Thing I Did"
   },
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :tags, type: {:list, :binary}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -595,7 +596,7 @@ iex> data = %{
       sleep_timeout: 5000, timezone: "EST"
     }
   },
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine580.Player.Config}, validator: :default}]
 }
 
 iex> data = %{
@@ -611,7 +612,7 @@ iex> data = %{
   errors: [config: [sleep_timeout: "expected a non_neg_integer, got: -5000"]],
   params: %{"config" => %{"sleep_timeout" => -5000, "timezone" => "EST"}, "name" => "Leo", "score" => 1600},
   struct: %Player{config: nil, name: "Leo", score: 1600},
-  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine580.Player.Config}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->

--- a/README.md
+++ b/README.md
@@ -285,10 +285,11 @@ Checkout the [types](./TYPES.md) docs for more on what types Breakfast supports.
 
 You might be asking, what's this `%Yogurt{}` thing?
 
-A `%Yogurt{}` represents the result of a decoding. It contains three pieces of data:
+A `%Yogurt{}` represents the result of a decoding. It contains four pieces of data:
 - `params`: The original input params that you asked Breakfast to decode
 - `errors`: A list of human-readable string errors that were accumulated when trying to decode the params
 - `struct`: The decoded data that's been casted to the well-defined struct
+- `fields`: The fields of the struct as a list of `Breakfast.Field`s
 
 In your day-to-day programming, you can pattern match on a `%Yogurt{}` for control-flow, where an empty `:errors` list indicates that the decoding was successful:
 
@@ -386,7 +387,7 @@ iex> data = %{
   errors: [],
   params: %{"SettingsName" => "Control Pannel", "timeout" => "1500", "volume" => 8},
   struct: %Settings{name: "Control Pannel", timeout: 1500, volume: 8},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :volume, type: :integer, validator: :valid_volume}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :volume, type: :integer, validator: :valid_volume}]
 }
 
 iex> data = %{
@@ -399,7 +400,7 @@ iex> data = %{
   errors: [name: "value not found", timeout: "cast error", volume: "expected an integer in 0..100, got: -100"],
   params: %{"name" => "Control Pannel", "timeout" => 1500, "volume" => -100},
   struct: %Settings{name: nil, timeout: nil, volume: nil},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine379.Settings, name: :volume, type: :integer, validator: :valid_volume}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :volume, type: :integer, validator: :valid_volume}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -448,7 +449,7 @@ iex> data = %{"R" => "10", "G" => "20", "B" => "30"}
   errors: [],
   params: %{"B" => "30", "G" => "20", "R" => "10"},
   struct: %RGBColor{b: 30, g: 20, r: 10},
-  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
+  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
 }
 
 iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
@@ -457,7 +458,7 @@ iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
   errors: [r: "value not found", g: "cast error", b: "expected an integer between 0 and 255, got: 500"],
   params: %{"B" => "500", "G" => "Twenty", "r" => "10"},
   struct: %RGBColor{b: nil, g: nil, r: nil},
-  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine445.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
+  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -493,7 +494,7 @@ iex> data = ["Sully", 37, "sully@aol.com"]
   errors: [],
   params: ["Sully", 37, "sully@aol.com"],
   struct: %SpreadsheetRow{age: 37, email: "sully@aol.com", name: "Sully"},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine490.SpreadsheetRow, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine490.SpreadsheetRow, name: :age, type: :non_neg_integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine490.SpreadsheetRow, name: :email, type: :binary, validator: :default}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine491.SpreadsheetRow, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine491.SpreadsheetRow, name: :age, type: :non_neg_integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine491.SpreadsheetRow, name: :email, type: :binary, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -527,7 +528,7 @@ iex> data = %{
     tags: [],
     title: "Cool Thing I Did"
   },
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :tags, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :tags, type: {:list, :binary}, validator: :default}]
 }
 
 iex> data = %{
@@ -544,7 +545,7 @@ iex> data = %{
     tags: ["blockchain", "crypto"],
     title: "Cool Thing I Did"
   },
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine517.Post, name: :tags, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :tags, type: {:list, :binary}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -596,7 +597,7 @@ iex> data = %{
       sleep_timeout: 5000, timezone: "EST"
     }
   },
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine580.Player.Config}, validator: :default}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine581.Player.Config}, validator: :default}]
 }
 
 iex> data = %{
@@ -612,7 +613,7 @@ iex> data = %{
   errors: [config: [sleep_timeout: "expected a non_neg_integer, got: -5000"]],
   params: %{"config" => %{"sleep_timeout" => -5000, "timezone" => "EST"}, "name" => "Leo", "score" => 1600},
   struct: %Player{config: nil, name: "Leo", score: 1600},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine580.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine580.Player.Config}, validator: :default}]
+  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine581.Player.Config}, validator: :default}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [],
   params: %{"email" => "john@aol.com", "id" => 1, "roles" => ["admin", "exec"]},
-  struct: %User{email: "john@aol.com", id: 1, roles: ["admin", "exec"]}
+  struct: %User{email: "john@aol.com", id: 1, roles: ["admin", "exec"]},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 
 iex> data = %{
@@ -199,7 +200,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [],
   params: %{"age" => 67, "email" => "leo@aol.com", "roles" => ["exec", "admin"]},
-  struct: %User{age: 67, email: "leo@aol.com", roles: ["exec", "admin"]}
+  struct: %User{age: 67, email: "leo@aol.com", roles: ["exec", "admin"]},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -231,7 +233,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [age: "expected a non_neg_integer, got: -5"],
   params: %{"age" => -5, "name" => "Sean"},
-  struct: %User{age: nil, name: "Sean"}
+  struct: %User{age: nil, name: "Sean"},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -257,7 +260,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [],
   params: %{"payload" => %{"some" => "data"}, "status" => :success},
-  struct: %Request{payload: %{"some" => "data"}, status: :success}
+  struct: %Request{payload: %{"some" => "data"}, status: :success},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 
 iex> data = %{
@@ -268,7 +272,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [status: "expected one of :pending | :success | :failed, got: :waiting"],
   params: %{"payload" => %{"some" => "data"}, "status" => :waiting},
-  struct: %Request{payload: %{"some" => "data"}, status: nil}
+  struct: %Request{payload: %{"some" => "data"}, status: nil},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -379,7 +384,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [],
   params: %{"SettingsName" => "Control Pannel", "timeout" => "1500", "volume" => 8},
-  struct: %Settings{name: "Control Pannel", timeout: 1500, volume: 8}
+  struct: %Settings{name: "Control Pannel", timeout: 1500, volume: 8},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 
 iex> data = %{
@@ -391,7 +397,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [name: "value not found", timeout: "cast error", volume: "expected an integer in 0..100, got: -100"],
   params: %{"name" => "Control Pannel", "timeout" => 1500, "volume" => -100},
-  struct: %Settings{name: nil, timeout: nil, volume: nil}
+  struct: %Settings{name: nil, timeout: nil, volume: nil},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -439,7 +446,8 @@ iex> data = %{"R" => "10", "G" => "20", "B" => "30"}
 %Breakfast.Yogurt{
   errors: [],
   params: %{"B" => "30", "G" => "20", "R" => "10"},
-  struct: %RGBColor{b: 30, g: 20, r: 10}
+  struct: %RGBColor{b: 30, g: 20, r: 10},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 
 iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
@@ -447,7 +455,8 @@ iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
 %Breakfast.Yogurt{
   errors: [r: "value not found", g: "cast error", b: "expected an integer between 0 and 255, got: 500"],
   params: %{"B" => "500", "G" => "Twenty", "r" => "10"},
-  struct: %RGBColor{b: nil, g: nil, r: nil}
+  struct: %RGBColor{b: nil, g: nil, r: nil},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -482,7 +491,8 @@ iex> data = ["Sully", 37, "sully@aol.com"]
 %Breakfast.Yogurt{
   errors: [],
   params: ["Sully", 37, "sully@aol.com"],
-  struct: %SpreadsheetRow{age: 37, email: "sully@aol.com", name: "Sully"}
+  struct: %SpreadsheetRow{age: 37, email: "sully@aol.com", name: "Sully"},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -515,7 +525,8 @@ iex> data = %{
     content: "Thanks for reading!",
     tags: [],
     title: "Cool Thing I Did"
-  }
+  },
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 
 iex> data = %{
@@ -531,7 +542,8 @@ iex> data = %{
     content: "Thanks for reading!",
     tags: ["blockchain", "crypto"],
     title: "Cool Thing I Did"
-  }
+  },
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -582,7 +594,8 @@ iex> data = %{
     config: %Player.Config{
       sleep_timeout: 5000, timezone: "EST"
     }
-  }
+  },
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 
 iex> data = %{
@@ -597,7 +610,8 @@ iex> data = %{
 %Breakfast.Yogurt{
   errors: [config: [sleep_timeout: "expected a non_neg_integer, got: -5000"]],
   params: %{"config" => %{"sleep_timeout" => -5000, "timezone" => "EST"}, "name" => "Leo", "score" => 1600},
-  struct: %Player{config: nil, name: "Leo", score: 1600}
+  struct: %Player{config: nil, name: "Leo", score: 1600},
+  fields: [%Breakfast.Field{}, %Breakfast.Field{}, %Breakfast.Field{}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ iex> data = %{
   errors: [],
   params: %{"email" => "john@aol.com", "id" => 1, "roles" => ["admin", "exec"]},
   struct: %User{email: "john@aol.com", id: 1, roles: ["admin", "exec"]},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :id, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :email, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :roles, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{name: :id}, %Breakfast.Field{name: :email}, %Breakfast.Field{name: :roles}]
 }
 
 iex> data = %{
@@ -119,7 +119,7 @@ iex> data = %{
   errors: [roles: "expected a list of type :binary, got a list with at least one invalid element: expected a binary, got: :exec"],
   params: %{"email" => "john@aol.com", "id" => 1, "roles" => ["admin", :exec]},
   struct: %User{email: "john@aol.com", id: 1, roles: nil},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :id, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :email, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine99.User, name: :roles, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{name: :id}, %Breakfast.Field{name: :email}, %Breakfast.Field{name: :roles}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -202,7 +202,7 @@ iex> data = %{
   errors: [],
   params: %{"age" => 67, "email" => "leo@aol.com", "roles" => ["exec", "admin"]},
   struct: %User{age: 67, email: "leo@aol.com", roles: ["exec", "admin"]},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine195.User, name: :email, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine195.User, name: :age, type: :non_neg_integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine195.User, name: :roles, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{name: :email}, %Breakfast.Field{name: :age}, %Breakfast.Field{name: :roles}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -235,7 +235,7 @@ iex> data = %{
   errors: [age: "expected a non_neg_integer, got: -5"],
   params: %{"age" => -5, "name" => "Sean"},
   struct: %User{age: nil, name: "Sean"},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine229.User, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine229.User, name: :age, type: :non_neg_integer, validator: :default}]
+  fields: [%Breakfast.Field{name: :name}, %Breakfast.Field{name: :age}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -262,7 +262,7 @@ iex> data = %{
   errors: [],
   params: %{"payload" => %{"some" => "data"}, "status" => :success},
   struct: %Request{payload: %{"some" => "data"}, status: :success},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :payload, type: :map, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :status, type: {:union, [literal: :pending, literal: :success, literal: :failed]}, validator: :default}]
+  fields: [%Breakfast.Field{name: :payload}, %Breakfast.Field{name: :status}]
 }
 
 iex> data = %{
@@ -274,7 +274,7 @@ iex> data = %{
   errors: [status: "expected one of :pending | :success | :failed, got: :waiting"],
   params: %{"payload" => %{"some" => "data"}, "status" => :waiting},
   struct: %Request{payload: %{"some" => "data"}, status: nil},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :payload, type: :map, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine256.Request, name: :status, type: {:union, [literal: :pending, literal: :success, literal: :failed]}, validator: :default}]
+  fields: [%Breakfast.Field{name: :payload}, %Breakfast.Field{name: :status}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -387,7 +387,7 @@ iex> data = %{
   errors: [],
   params: %{"SettingsName" => "Control Pannel", "timeout" => "1500", "volume" => 8},
   struct: %Settings{name: "Control Pannel", timeout: 1500, volume: 8},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :volume, type: :integer, validator: :valid_volume}]
+  fields: [%Breakfast.Field{name: :name}, %Breakfast.Field{name: :timeout}, %Breakfast.Field{name: :volume}]
 }
 
 iex> data = %{
@@ -400,7 +400,7 @@ iex> data = %{
   errors: [name: "value not found", timeout: "cast error", volume: "expected an integer in 0..100, got: -100"],
   params: %{"name" => "Control Pannel", "timeout" => 1500, "volume" => -100},
   struct: %Settings{name: nil, timeout: nil, volume: nil},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_name, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :timeout, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine380.Settings, name: :volume, type: :integer, validator: :valid_volume}]
+  fields: [%Breakfast.Field{name: :name}, %Breakfast.Field{name: :timeout}, %Breakfast.Field{name: :volume}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -449,7 +449,7 @@ iex> data = %{"R" => "10", "G" => "20", "B" => "30"}
   errors: [],
   params: %{"B" => "30", "G" => "20", "R" => "10"},
   struct: %RGBColor{b: 30, g: 20, r: 10},
-  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
+  fields: [%Breakfast.Field{name: :r}, %Breakfast.Field{name: :g}, %Breakfast.Field{name: :b}]
 }
 
 iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
@@ -458,7 +458,7 @@ iex> data = %{"r" => "10", "G" => "Twenty", "B" => "500"}
   errors: [r: "value not found", g: "cast error", b: "expected an integer between 0 and 255, got: 500"],
   params: %{"B" => "500", "G" => "Twenty", "r" => "10"},
   struct: %RGBColor{b: nil, g: nil, r: nil},
-  fields: [%Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :r, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :g, type: :integer, validator: :valid_rgb_value}, %Breakfast.Field{caster: :int_from_string, default: :error, fetcher: :fetch_upcase_key, mod: BreakfastTest.MarkdownTest.README.BlockAtLine446.RGBColor, name: :b, type: :integer, validator: :valid_rgb_value}]
+  fields: [%Breakfast.Field{name: :r}, %Breakfast.Field{name: :g}, %Breakfast.Field{name: :b}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -494,7 +494,7 @@ iex> data = ["Sully", 37, "sully@aol.com"]
   errors: [],
   params: ["Sully", 37, "sully@aol.com"],
   struct: %SpreadsheetRow{age: 37, email: "sully@aol.com", name: "Sully"},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine491.SpreadsheetRow, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine491.SpreadsheetRow, name: :age, type: :non_neg_integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :fetch_at_list_index, mod: BreakfastTest.MarkdownTest.README.BlockAtLine491.SpreadsheetRow, name: :email, type: :binary, validator: :default}]
+  fields: [%Breakfast.Field{name: :name}, %Breakfast.Field{name: :age}, %Breakfast.Field{name: :email}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -528,7 +528,7 @@ iex> data = %{
     tags: [],
     title: "Cool Thing I Did"
   },
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :tags, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{name: :title}, %Breakfast.Field{name: :content}, %Breakfast.Field{name: :tags}]
 }
 
 iex> data = %{
@@ -545,7 +545,7 @@ iex> data = %{
     tags: ["blockchain", "crypto"],
     title: "Cool Thing I Did"
   },
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :title, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :content, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: {:ok, []}, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine518.Post, name: :tags, type: {:list, :binary}, validator: :default}]
+  fields: [%Breakfast.Field{name: :title}, %Breakfast.Field{name: :content}, %Breakfast.Field{name: :tags}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->
@@ -597,7 +597,7 @@ iex> data = %{
       sleep_timeout: 5000, timezone: "EST"
     }
   },
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine581.Player.Config}, validator: :default}]
+  fields: [%Breakfast.Field{name: :name}, %Breakfast.Field{name: :score}, %Breakfast.Field{name: :config}]
 }
 
 iex> data = %{
@@ -613,7 +613,7 @@ iex> data = %{
   errors: [config: [sleep_timeout: "expected a non_neg_integer, got: -5000"]],
   params: %{"config" => %{"sleep_timeout" => -5000, "timezone" => "EST"}, "name" => "Leo", "score" => 1600},
   struct: %Player{config: nil, name: "Leo", score: 1600},
-  fields: [%Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :name, type: :binary, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :score, type: :integer, validator: :default}, %Breakfast.Field{caster: :default, default: :error, fetcher: :default, mod: BreakfastTest.MarkdownTest.README.BlockAtLine581.Player, name: :config, type: {:cereal, BreakfastTest.MarkdownTest.README.BlockAtLine581.Player.Config}, validator: :default}]
+  fields: [%Breakfast.Field{name: :name}, %Breakfast.Field{name: :score}, %Breakfast.Field{name: :config}]
 }
 ```
 <!--- MARKDOWN_TEST_END -->

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -45,10 +45,12 @@ defmodule Breakfast do
   """
   @spec decode(mod :: module(), params :: term()) :: Yogurt.t()
   def decode(mod, params) do
+    fields = mod.__cereal__(:fields)
+
     yogurt =
       Enum.reduce(
-        mod.__cereal__(:fields),
-        %Yogurt{struct: struct(mod), params: params},
+        fields,
+        %Yogurt{struct: struct(mod), params: params, fields: fields},
         fn %Field{
              name: name,
              fetcher: fetcher,

--- a/lib/breakfast/field.ex
+++ b/lib/breakfast/field.ex
@@ -1,16 +1,27 @@
 defmodule Breakfast.Field do
-  @moduledoc false
+  @moduledoc """
+  The `%#{__MODULE__}{}` struct contains all the information related to a particular
+  field on a struct created with `cereal`:
+
+  - `mod`: The name of the module that defines this field
+  - `name`: The name of the field
+  - `type`: The type of the field
+  - `fetcher`: The function that'll be used to fetch the value for this field
+  - `caster`:  The function that'll be used to cast the value for this field
+  - `validator`:  The function that'll be used to validate the value for this field
+  - `default`:  The default value
+  """
   use TypedStruct
 
   @type type :: atom() | {:cereal, module()} | {atom(), term()}
 
   typedstruct do
-    field :mod, atom()
+    field :mod, module()
     field :name, atom()
     field :type, type()
-    field :fetcher, atom()
-    field :caster, atom()
-    field :validator, atom()
+    field :fetcher, atom() | (any(), any() -> any()) | :default
+    field :caster, atom() | (any() -> {:ok, any()} | :error) | :default
+    field :validator, atom() | (any() -> [any()]) | :default
     field :default, {:ok, term()} | :error
   end
 end

--- a/lib/breakfast/yogurt.ex
+++ b/lib/breakfast/yogurt.ex
@@ -13,6 +13,7 @@ defmodule Breakfast.Yogurt do
     field :params, term(), default: nil
     field :errors, [String.t()], default: []
     field :struct, struct(), default: nil
+    field :fields, [Breakfast.Field.t()], default: []
   end
 
   @spec valid?(t()) :: boolean()

--- a/lib/breakfast/yogurt.ex
+++ b/lib/breakfast/yogurt.ex
@@ -1,6 +1,6 @@
 defmodule Breakfast.Yogurt do
   @moduledoc """
-  The %#{__MODULE__}{} struct is the resulting value of a call to `Breakfast.decode/2`.
+  The `%#{__MODULE__}{}` struct is the resulting value of a call to `Breakfast.decode/2`.
 
   It contains all the information regarding a particular decode, including:
   - the params passed in

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Breakfast.MixProject do
       {:mix_test_watch, "~> 0.8", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.7", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.12.0", only: [:dev, :test], runtime: false},
-      {:markdown_test, "0.1.1", only: :test},
+      {:markdown_test, "0.1.2", only: :test},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "markdown_test": {:hex, :markdown_test, "0.1.1", "d9dd50538f691c3d74f0f5a48aff418874319018f780868e86970cf4a8dc1021", [:mix], [], "hexpm"},
+  "markdown_test": {:hex, :markdown_test, "0.1.2", "3f260e3ca99dc76a170a9d7cfb13c501ca3263a335dec1c6d664b00c8b492cf2", [:mix], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.9.0", "c72132a6071261893518fa08e121e911c9358713f62794a90c95db59042af375", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -127,7 +127,36 @@ defmodule BreakfastTest do
                  age: 28,
                  first_name: "shawn",
                  last_name: "trembles"
-               }
+               },
+               fields: [
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: &BreakfastTest.JSUser.camel_key_fetch/2,
+                   mod: BreakfastTest.JSUser,
+                   name: :first_name,
+                   type: :binary,
+                   validator: :default
+                 },
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: &BreakfastTest.JSUser.camel_key_fetch/2,
+                   mod: BreakfastTest.JSUser,
+                   name: :last_name,
+                   type: :binary,
+                   validator: :default
+                 },
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: :fetch_age,
+                   mod: BreakfastTest.JSUser,
+                   name: :age,
+                   type: :integer,
+                   validator: :default
+                 }
+               ]
              }
     end
 
@@ -201,7 +230,36 @@ defmodule BreakfastTest do
                  },
                  colors: [%Server.RGBColor{r: 10, g: 20, b: 30}],
                  email: "some@email.com"
-               }
+               },
+               fields: [
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: :default,
+                   mod: BreakfastTest.Server,
+                   name: :email,
+                   type: :binary,
+                   validator: :default
+                 },
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: :default,
+                   mod: BreakfastTest.Server,
+                   name: :config,
+                   type: {:cereal, BreakfastTest.Server.Config},
+                   validator: :default
+                 },
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: :default,
+                   mod: BreakfastTest.Server,
+                   name: :colors,
+                   type: {:list, {:cereal, BreakfastTest.Server.RGBColor}},
+                   validator: :default
+                 }
+               ]
              }
     end
 
@@ -277,7 +335,18 @@ defmodule BreakfastTest do
                      c: %SuperNestedDecoder.A.B.C{value: 1}
                    }
                  }
-               }
+               },
+               fields: [
+                 %Breakfast.Field{
+                   caster: :default,
+                   default: :error,
+                   fetcher: :default,
+                   mod: BreakfastTest.SuperNestedDecoder,
+                   name: :a,
+                   type: {:cereal, BreakfastTest.SuperNestedDecoder.A},
+                   validator: :default
+                 }
+               ]
              }
     end
   end
@@ -539,7 +608,36 @@ defmodule BreakfastTest do
                    age: 20,
                    email: "my@email.com",
                    roles: ["user", "exec"]
-                 }
+                 },
+                 fields: [
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleOne.User,
+                     name: :email,
+                     type: :binary,
+                     validator: :default
+                   },
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleOne.User,
+                     name: :age,
+                     type: :integer,
+                     validator: :default
+                   },
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleOne.User,
+                     name: :roles,
+                     type: {:list, :binary},
+                     validator: :default
+                   }
+                 ]
                }
 
       assert Breakfast.decode(READMEExampleOne.User, %{params | "age" => 20.5}) ==
@@ -554,7 +652,36 @@ defmodule BreakfastTest do
                    age: nil,
                    email: "my@email.com",
                    roles: ["user", "exec"]
-                 }
+                 },
+                 fields: [
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleOne.User,
+                     name: :email,
+                     type: :binary,
+                     validator: :default
+                   },
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleOne.User,
+                     name: :age,
+                     type: :integer,
+                     validator: :default
+                   },
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleOne.User,
+                     name: :roles,
+                     type: {:list, :binary},
+                     validator: :default
+                   }
+                 ]
                }
     end
 
@@ -577,7 +704,36 @@ defmodule BreakfastTest do
                    age: 20,
                    email: "my@email.com",
                    roles: ["user", "exec"]
-                 }
+                 },
+                 fields: [
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleTwo.User,
+                     name: :email,
+                     type: :binary,
+                     validator: :default
+                   },
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :default,
+                     mod: BreakfastTest.READMEExampleTwo.User,
+                     name: :age,
+                     type: :integer,
+                     validator: :default
+                   },
+                   %Breakfast.Field{
+                     caster: :default,
+                     default: :error,
+                     fetcher: :fetch_roles,
+                     mod: BreakfastTest.READMEExampleTwo.User,
+                     name: :roles,
+                     type: {:list, :binary},
+                     validator: :default
+                   }
+                 ]
                }
     end
   end


### PR DESCRIPTION
Adds the list of `%Field{}`s to `%Yogurt{}`.

This can be useful when implementing protocols such as [`Phoenix.HTML.FormData`](https://hexdocs.pm/phoenix_html/Phoenix.HTML.FormData.html) to know the type of a field for example.