### PR TITLE
Cast internal breakfasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ iex> data = %{
 ...> }
 ...> Breakfast.decode(User, data)
 %Breakfast.Yogurt{
-  errors: [roles: "expected a list of type :binary, got a list with at least one invalid element: expected a binary, got: :exec"],
+  errors: [roles: "expected a list of type binary(), got a list with at least one invalid element: expected a binary, got: :exec"],
   params: %{"email" => "john@aol.com", "id" => 1, "roles" => ["admin", :exec]},
   struct: %User{email: "john@aol.com", id: 1, roles: nil},
   fields: [%Breakfast.Field{name: :id}, %Breakfast.Field{name: :email}, %Breakfast.Field{name: :roles}]

--- a/lib/breakfast.ex
+++ b/lib/breakfast.ex
@@ -126,7 +126,8 @@ defmodule Breakfast do
 
   @spec find_all_nested_decoder_paths_in_type(Field.t()) :: [{list(), term()}]
   defp find_all_nested_decoder_paths_in_type(field) do
-    do_find_all_nested_decoder_paths_in_type(field, field.type, [], [])
+    field
+    |> do_find_all_nested_decoder_paths_in_type(field.type, [], [])
     |> Enum.map(fn {path, type} -> {Enum.reverse(path), type} end)
   end
 
@@ -272,9 +273,7 @@ defmodule Breakfast do
     do_cast_any_nested_decoder_values({rest, type}, value, false)
   end
 
-  defp do_cast_any_nested_decoder_values(_path, value, _strict?) do
-    value
-  end
+  defp do_cast_any_nested_decoder_values(_path, value, _strict?), do: value
 
   @spec cast(term(), Field.t()) :: result(term())
   defp cast(value, field) do

--- a/lib/breakfast/type.ex
+++ b/lib/breakfast/type.ex
@@ -465,7 +465,7 @@ defmodule Breakfast.Type do
 
   defp display_type({:list, type}), do: "[#{display_type(type)}]"
 
-  defp display_type(:atom), do: "atom()"
+  defp display_type(type) when is_atom(type), do: "#{type}()"
 
   defp display_type({:literal, literal}), do: inspect(literal)
 

--- a/lib/breakfast/type.ex
+++ b/lib/breakfast/type.ex
@@ -384,21 +384,21 @@ defmodule Breakfast.Type do
         end
 
       {key_type, value_type}, acc ->
-        Enum.any?(map, fn {key, value} ->
+        Enum.reduce_while(map, [], fn {key, value}, acc ->
           case {validate(key_type, key), validate(value_type, value)} do
             {[], []} ->
-              true
+              {:halt, :ok}
 
-            _other ->
-              false
+            {key_errors, value_errors} ->
+              {:cont, key_errors ++ value_errors ++ acc}
           end
         end)
         |> case do
-          true ->
-            acc
-
-          false ->
+          :ok ->
             []
+
+          errors ->
+            errors ++ acc
         end
     end)
   end

--- a/lib/breakfast/type.ex
+++ b/lib/breakfast/type.ex
@@ -204,7 +204,7 @@ defmodule Breakfast.Type do
   end
 
   @spec validate(Field.type(), term()) :: [String.t()]
-  def validate({:tuple, union_types}, term) do
+  def validate({:tuple, union_types} = type, term) do
     with true <- is_tuple(term),
          term_as_list = Tuple.to_list(term),
          true <- length(union_types) == length(term_as_list),
@@ -213,7 +213,9 @@ defmodule Breakfast.Type do
       []
     else
       false ->
-        ["expected #{inspect(List.to_tuple(union_types))}, got: #{inspect(term)}"]
+        [
+          "expected a tuple with the following shape: #{display_type(type)}, got: #{inspect(term)}"
+        ]
     end
   end
 
@@ -430,11 +432,40 @@ defmodule Breakfast.Type do
     "required(#{displayed_fields})"
   end
 
+  defp display_type({:tuple, element_types}) do
+    tuple_contents =
+      element_types
+      |> Enum.map(&display_type/1)
+      |> Enum.join(", ")
+
+    "{#{tuple_contents}}"
+  end
+
   defp display_type({:union, types}) do
     types
     |> Enum.map(&display_type/1)
     |> Enum.join(" | ")
   end
+
+  defp display_type({:map, {required, optional}}) do
+    fields =
+      [required: required, optional: optional]
+      |> Enum.flat_map(fn {require_type, fields} ->
+        Enum.map(fields, fn {key_type, value_type} ->
+          "#{require_type}(#{display_type(key_type)}) => #{display_type(value_type)}"
+        end)
+      end)
+
+    "%{#{Enum.join(fields, "\n")}}"
+  end
+
+  defp display_type({:cereal, module}) do
+    "#{inspect(module)}.t()"
+  end
+
+  defp display_type({:list, type}), do: "[#{display_type(type)}]"
+
+  defp display_type(:atom), do: "atom()"
 
   defp display_type({:literal, literal}), do: inspect(literal)
 

--- a/test/breakfast_test.exs
+++ b/test/breakfast_test.exs
@@ -408,7 +408,7 @@ defmodule BreakfastTest do
 
       assert result.errors == [
                tag_groupings:
-                 "expected a list of type {:list, :binary}, got a list with at least one invalid element: expected a list of type :binary, got: \"user\", expected a list of type :binary, got: \"admin\""
+                 "expected a list of type [binary()], got a list with at least one invalid element: expected a list of type binary(), got: \"user\", expected a list of type binary(), got: \"admin\""
              ]
     end
 
@@ -418,7 +418,11 @@ defmodule BreakfastTest do
 
       params = %{params | "ratio" => [7, 5.0]}
       result = Breakfast.decode(ColorData, params)
-      assert result.errors == [ratio: "expected {:integer, :integer}, got: {7, 5.0}"]
+
+      assert result.errors == [
+               ratio:
+                 "expected a tuple with the following shape: {integer(), integer()}, got: {7, 5.0}"
+             ]
     end
   end
 
@@ -902,7 +906,7 @@ defmodule BreakfastTest do
                  boolean: "expected a boolean, got: \"true\"",
                  keyword: "expected a keyword, got: %{name: :cool}",
                  typed_keyword:
-                   "expected a keyword with values of type :binary, got: a keyword with invalid values: [name: [\"expected a binary, got: 5\"]]",
+                   "expected a keyword with values of type binary(), got: a keyword with invalid values: [name: [\"expected a binary, got: 5\"]]",
                  map: "expected a map, got: []",
                  struct: "expected a struct, got: %{name: :cool}",
                  tuple: "expected a tuple, got: [:apples, :oranges]",
@@ -915,31 +919,33 @@ defmodule BreakfastTest do
                  list: "expected a list, got: {}",
                  nonempty_list: "expected a nonempty_list, got: []",
                  typed_list:
-                   "expected a list of type :atom, got a list with at least one invalid element: expected a atom, got: \"oranges\"",
-                 nonempty_typed_list: "expected a nonempty_list of type :atom, got: []",
+                   "expected a list of type atom(), got a list with at least one invalid element: expected a atom, got: \"oranges\"",
+                 nonempty_typed_list: "expected a nonempty_list of type atom(), got: []",
                  mfa: "expected a mfa, got: {Breakfast, :decode, 2.0}",
                  module: "expected a module, got: \"Breakfast\"",
                  literal_atom: "expected :hey, got: :apples",
                  literal_integer: "expected 5, got: 6",
                  literal_integer_in_range: "expected an integer in 5..10, got: 100",
                  literal_typed_list:
-                   "expected a list of type :atom, got a list with at least one invalid element: expected a atom, got: \"oranges\"",
+                   "expected a list of type atom(), got a list with at least one invalid element: expected a atom, got: \"oranges\"",
                  literal_empty_list: "expected a empty_list, got: [1]",
-                 literal_nonempty_list: "expected a nonempty_list of type :any, got: []",
-                 literal_typed_nonempty_list: "expected a nonempty_list of type :atom, got: []",
+                 literal_nonempty_list: "expected a nonempty_list of type any(), got: []",
+                 literal_typed_nonempty_list: "expected a nonempty_list of type atom(), got: []",
                  literal_keyword:
-                   "expected a keyword with values of type required(format: :atom), got: a keyword with invalid values: [format: [\"expected a atom, got: \\\"standard\\\"\"]]",
+                   "expected a keyword with values of type required(format: atom()), got: a keyword with invalid values: [format: [\"expected a atom, got: \\\"standard\\\"\"]]",
                  literal_empty_map: "expected a empty_map, got: %{key: :value}",
                  literal_atom_key_map:
                    "expected a field with key :format and value of type :atom, got: invalid value: [\"expected a atom, got: \\\"standard\\\"\"]",
+                 literal_required_option_key_map: "expected a binary, got: :format",
                  literal_struct:
                    "expected a %Breakfast.TestDefinitions.Struct{}, got: %Breakfast.TestDefinitions.OtherStruct{email: \"\"}",
                  literal_typed_struct:
                    "expected a field with key :name and value of type :binary, got: invalid value: [\"expected a binary, got: 42\"]",
-                 literal_empty_tuple: "expected {}, got: {:apples}",
+                 literal_empty_tuple:
+                   "expected a tuple with the following shape: {}, got: {:apples}",
                  literal_typed_tuple:
-                   "expected {:atom, :binary, :integer}, got: {\"apples\", \"oranges\", 123.56}",
-                 union_type: "expected one of :integer | :never | :infinity, got: :always",
+                   "expected a tuple with the following shape: {atom(), binary(), integer()}, got: {\"apples\", \"oranges\", 123.56}",
+                 union_type: "expected one of integer() | :never | :infinity, got: :always",
                  remote: "expected one of :red | :green | :blue, got: :purple"
                ]
     end
@@ -985,7 +991,7 @@ defmodule BreakfastTest do
       user_params = %{"email" => "leo@aol.com"}
       guest_params = %{"username" => "LeoTheCat"}
 
-      valid_params = %{
+      params = %{
         "decoder" => user_params,
         "list" => [user_params],
         "tuple" => {:user, user_params},
@@ -1000,11 +1006,11 @@ defmodule BreakfastTest do
         "nested_not_present" => {:params, [%{"user" => nil}]}
       }
 
-      %{valid_params: valid_params}
+      %{params: params}
     end
 
     test "field who's types have a decoder nested in them should have those values get automatically casted",
-         %{valid_params: params} do
+         %{params: params} do
       result = Breakfast.decode(NestedDecoderCasting, params)
 
       assert result.errors == []
@@ -1032,6 +1038,21 @@ defmodule BreakfastTest do
                  username: "LeoTheCat"
                }
              }
+    end
+
+    test "the error for an invalid value within a nested decoder should make sense",
+         %{params: params} do
+      invalid_params = %{
+        params
+        | "nested_not_present" => {:params, [%{"user" => :bad_value}]}
+      }
+
+      result = Breakfast.decode(NestedDecoderCasting, invalid_params)
+
+      assert result.errors == [
+               nested_not_present:
+                 "expected a tuple with the following shape: {atom(), [%{required(binary()) => BreakfastTest.NestedDecoderCasting.User.t() | nil}]}, got: {:params, [%{\"user\" => :bad_value}]}"
+             ]
     end
   end
 end


### PR DESCRIPTION
The goal with this PR was to make sure that we properly cast values at any level in the data structure if there type was defined to be a Breakfast decoder.

The result of these efforts is illustrated in one of the new tests: https://github.com/MainShayne233/breakfast/pull/14/files#diff-dadb5abb4f15bc52d060faeb63cf12caR1018

This is done by finding all the places in the defined type where this casting might need to occur, attempting that casting, and handling weird cases the best that it can.

This solution isn't extremely robust, and you can have cases where an error might seem like obscure, but I think we'd be pushing the limits of what Elixir can do by trying to go much further than this, and should hopefully serve well for most cases.

Also:
- Fixed a bug where invalid maps would be determined to be valid
- Improved some of the type displaying in error messages


P.S. @evuez I took many stabs at trying to solve this problem, and this was the best I could come up with. I'd be very willing to scrap it if you can think of a better solution.